### PR TITLE
Ensure output folder exists before processing video

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,6 +75,7 @@ def process_video(video_path, output_folder, include_timestamps=False):
         output_folder (str): Path where output files will be saved.
         include_timestamps (bool): Whether to include timestamps in subtitles.
     """
+    os.makedirs(output_folder, exist_ok=True)
     print(f"Processing video: {video_path}")
 
     # Prepare paths


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Added functionality to ensure the output folder exists before processing a video.
- Utilized `os.makedirs` with `exist_ok=True` to create the output directory if it does not already exist, preventing potential errors during video processing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Ensure output folder exists before processing video</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.py

<li>Added a check to ensure the output folder exists before processing the <br>video.<br> <li> Used <code>os.makedirs</code> with <code>exist_ok=True</code> to create the folder if it doesn't <br>exist.<br>


</details>


  </td>
  <td><a href="https://github.com/barnett-yuxiang/video-transcribe/pull/2/files#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information